### PR TITLE
fix dojo/request dependency

### DIFF
--- a/Request.js
+++ b/Request.js
@@ -1,5 +1,5 @@
 define([
-	'dojo/request/registry',
+	'dojo/request',
 	'dojo/_base/lang',
 	'dojo/_base/array',
 	'dojo/json',

--- a/Rest.js
+++ b/Rest.js
@@ -1,5 +1,5 @@
 define([
-	'dojo/request/registry',
+	'dojo/request',
 	'dojo/_base/lang',
 	'dojo/json',
 	'dojo/io-query',


### PR DESCRIPTION
a couple of places were using dojo/request/registry as a dependency when they should have been using dojo/request.
