### PR TITLE
Added support for "before" for Memory and Rest

### DIFF
--- a/Rest.js
+++ b/Rest.js
@@ -65,6 +65,13 @@ define([
 			var hasId = typeof id !== 'undefined';
 			var parse = this.parse;
 			var store = this;
+
+			// Add `before` header so that the REST server can work out
+			// where to place the item
+			if(typeof(options.before) !== 'undefined'){
+				options.headers['X-rest-before'] = options.before === null ? 'null' : this.getIdentity(options.before);
+			}
+
 			return request(hasId ? this.target + id : this.target, {
 					method: hasId && !options.incremental ? 'PUT' : 'POST',
 					data: this.stringify(object),


### PR DESCRIPTION
Hi there,

This implements #6 for Memory.js and for Rest.js.
Two issues:

1)
In Rest.js I set "null" for the X-rest-before header. Ideally, the header should be left empty (that is, when the server sees that the X-rest-before header is there but it's empty, it means "place at the end"). However, Dojo doesn't allow empty headers (they are taken out):

https://github.com/dojo/dojo/blob/master/request/xhr.js#L205-L212

2)
In Cache.js, in `put()` an item is always deleted and then added again:

https://github.com/SitePen/dstore/blob/master/Cache.js#L149-L158

This means that even though my implementation of Memory moves as little as possible, it ends up always moving the item from its last position when using Memory.js as the caching store

Thanks for listening as ever!

Merc.
