### PR TITLE
Rest.js should only fire 'add' event if HTTP response is "201 (created)"

### DIFF
--- a/Rest.js
+++ b/Rest.js
@@ -73,17 +73,17 @@ define([
 					? { 'X-Put-Default-Position': (this.defaultNewToStart ? 'start' : 'end') }
 					: null);
 
-			var r = request(hasId ? this.target + id : this.target, {
-					method: hasId && !options.incremental ? 'PUT' : 'POST',
-					data: this.stringify(object),
-					headers: lang.mixin({
-						'Content-Type': 'application/json',
-						Accept: this.accepts,
-						'If-Match': options.overwrite === true ? '*' : null,
-						'If-None-Match': options.overwrite === false ? '*' : null
-					}, positionHeaders, this.headers, options.headers)
-				});
-			return r.then(function (response) {
+			var initialResponse = request(hasId ? this.target + id : this.target, {
+				method: hasId && !options.incremental ? 'PUT' : 'POST',
+				data: this.stringify(object),
+				headers: lang.mixin({
+					'Content-Type': 'application/json',
+					Accept: this.accepts,
+					'If-Match': options.overwrite === true ? '*' : null,
+					'If-None-Match': options.overwrite === false ? '*' : null
+				}, positionHeaders, this.headers, options.headers)
+			})
+			return initialResponse.then(function (response) {
 				var event = {};
 
 				if ('beforeId' in options) {
@@ -92,9 +92,7 @@ define([
 
 				var result = event.target = store._restore(store.parse(response), true) || object;
 
-				when( r.response, function( httpResponse ){
-					console.log( httpResponse );
-					//store.emit(options.overwrite === false ? 'add' : 'update', event);
+				when( initialResponse.response, function( httpResponse ){
 					store.emit(httpResponse.status == 201 ? 'add' : 'update', event);
 				});
 


### PR DESCRIPTION
Each store fires an event depending on whether an element was added or updated. In Memory, the event is decided by https://github.com/SitePen/dstore/blob/master/Memory.js#L73 :

```
var eventType = id in index ? 'update' : 'add',
```

Which makes sense. However, in Rest.js there is problem: the event is decided by https://github.com/SitePen/dstore/blob/master/Rest.js#L92:

```
store.emit(options.overwrite === false ? 'add' : 'update', event);
```

This is very wrong: `options.overwrite` doesn't tell you whether a new element was created or not. This in fact results in the `update` event being fired most of the time.

With REST, the only reliable way to find out whether an element was created is by looking as the HTTP code returned. Luckily, HTTP code `201 Created` is very reliable in terms of response code. So, it's safe to say that a 201 return code will imply `add`, whereas anything else will imply `update`. I realise that REST is a very foggy standard, but `201 Created` really is simple, and servers really ought to return 201 when they create a new resource following a PUT.

This PR addresses this issue. To do that, I use the `response` attribute of the XHR promise, which carries the HTTP status code.

Thank you as ever for listening :D
