### PR TITLE
Tree: Make parent and hasChildren properties configurable

### DIFF
--- a/Tree.js
+++ b/Tree.js
@@ -3,6 +3,19 @@ define([
 	/*=====, 'dstore/Store'=====*/
 ], function (declare /*=====, Store=====*/) {
 	return declare(null, {
+		// summary:
+		//		A basic mixin for adding hierarchical support to a store,
+		//		where children contain a property referencing their parent by ID,
+		//		and parents may contain a property indicating whether they have children.
+
+		// parentProperty: String
+		//		Name of property to inspect on children for their parent's identifier
+		parentProperty: 'parent',
+
+		// hasChildrenProperty: String
+		//		Name of property to inspect on items to indicate whether they have children
+		hasChildrenProperty: 'hasChildren',
+
 		constructor: function () {
 			this.root = this;
 		},
@@ -18,7 +31,7 @@ define([
 			//		The potential parent
 			// returns: boolean
 
-			return 'hasChildren' in object ? object.hasChildren : true;
+			return this.hasChildrenProperty in object ? object[this.hasChildrenProperty] : true;
 		},
 
 		getRootCollection: function () {
@@ -35,9 +48,10 @@ define([
 			//		The parent object
 			// returns: dstore/Store.Collection
 
-			return this.root.filter({
-				parent: object ? this.getIdentity(object) : null
-			});
+			var filterObject = {};
+			filterObject[this.parentProperty] = object ? this.getIdentity(object) : null;
+
+			return this.root.filter(filterObject);
 		}
 	});
 });

--- a/tests/Tree.js
+++ b/tests/Tree.js
@@ -2,26 +2,83 @@ define([
 	'intern!object',
 	'intern/chai!assert',
 	'dojo/_base/declare',
+	'dojo/_base/lang',
 	'dstore/Memory',
 	'dstore/Tree'
-], function (registerSuite, assert, declare, Memory, Tree) {
+], function (registerSuite, assert, declare, lang, Memory, Tree) {
 	var TestStore = declare([ Memory, Tree ]);
 
+	var data = [
+		{ parent: null, id: '1', name: 'root1' },
+		{ parent: '1', id: '1.1', name: 'child1.1' },
+		{ parent: '1', id: '1.2', name: 'child1.2' },
+		{ parent: '1.2', id: '1.2.1', name: 'grandchild1.2.1' },
+		{ parent: '1.2', id: '1.2.2', name: 'grandchild1.2.2' },
+		{ parent: '1', id: '1.3', name: 'child1.3' },
+		{ parent: null, id: '2', name: 'root2' },
+		{ parent: '2', id: '2.1', name: 'child2.1' },
+		{ parent: '2', id: '2.2', name: 'child2.2' },
+		{ parent: null, id: '3', name: 'root3' }
+	];
+
 	var store = new TestStore({
-		model: null,
-		data: [
-			{ parent: null, id: '1', name: 'root1' },
-			{ parent: '1', id: '1.1', name: 'child1.1' },
-			{ parent: '1', id: '1.2', name: 'child1.2' },
-			{ parent: '1.2', id: '1.2.1', name: 'grandchild1.2.1' },
-			{ parent: '1.2', id: '1.2.2', name: 'grandchild1.2.2' },
-			{ parent: '1', id: '1.3', name: 'child1.3' },
-			{ parent: null, id: '2', name: 'root2' },
-			{ parent: '2', id: '2.1', name: 'child2.1' },
-			{ parent: '2', id: '2.2', name: 'child2.2' },
-			{ parent: null, id: '3', name: 'root3' }
-		]
+		data: data
 	});
+
+	// Create a copy of data with a different parent property for testing custom properties
+	data = lang.clone(data);
+	for (var i = data.length; i--;) {
+		data[i].parentId = data[i].parent;
+		delete data[i].parent;
+	}
+	var customPropertyStore = new TestStore({
+		hasChildrenProperty: 'isParent',
+		parentProperty: 'parentId',
+		data: data
+	});
+
+	function createMayHaveChildrenTest(store, hasChildrenProperty) {
+		return function () {
+			var object = {};
+			assert.isTrue(store.mayHaveChildren(object));
+
+			object[hasChildrenProperty] = true;
+			assert.isTrue(store.mayHaveChildren(object));
+
+			object[hasChildrenProperty] = false;
+			assert.isFalse(store.mayHaveChildren(object));
+		};
+	}
+
+	function createGetChildrenTest(store, parentProperty) {
+		return function () {
+			var childlessObject = store.getSync('3');
+			var children = store.getChildren(childlessObject).fetchSync().slice();
+			assert.deepEqual(children, []);
+
+			// parentPropertyObject is mixed into items for deepEqual assertions,
+			// with dynamic parent property
+			var parentPropertyObject = {};
+			parentPropertyObject[parentProperty] = '1';
+
+			var parentObject = store.getSync('1');
+			children = store.getChildren(parentObject).fetchSync().slice();
+			assert.deepEqual(children, [
+				lang.mixin({ id: '1.1', name: 'child1.1' }, parentPropertyObject),
+				lang.mixin({ id: '1.2', name: 'child1.2' }, parentPropertyObject),
+				lang.mixin({ id: '1.3', name: 'child1.3' }, parentPropertyObject)
+			]);
+
+			parentPropertyObject[parentProperty] = '1.2';
+
+			var grandparentObject = store.getSync('1.2');
+			children = store.getChildren(grandparentObject).fetchSync().slice();
+			assert.deepEqual(children, [
+				lang.mixin({ id: '1.2.1', name: 'grandchild1.2.1' }, parentPropertyObject),
+				lang.mixin({ id: '1.2.2', name: 'grandchild1.2.2' }, parentPropertyObject)
+			]);
+		};
+	}
 
 	registerSuite({
 		name: 'dstore/Tree',
@@ -37,31 +94,10 @@ define([
 			]);
 		},
 
-		'mayHaveChildren': function () {
-			assert.isTrue(store.mayHaveChildren({}));
-			assert.isTrue(store.mayHaveChildren({ hasChildren: true }));
-			assert.isFalse(store.mayHaveChildren({ hasChildren: false }));
-		},
+		'mayHaveChildren': createMayHaveChildrenTest(store, 'hasChildren'),
+		'mayHaveChildren (custom hasChildrenProperty)': createMayHaveChildrenTest(customPropertyStore, 'isParent'),
 
-		'getChildren': function () {
-			var childlessObject = store.getSync('3');
-			var children = store.getChildren(childlessObject).fetchSync().slice();
-			assert.deepEqual(children, []);
-
-			var parentObject = store.getSync('1');
-			children = store.getChildren(parentObject).fetchSync().slice();
-			assert.deepEqual(children, [
-				{ parent: '1', id: '1.1', name: 'child1.1' },
-				{ parent: '1', id: '1.2', name: 'child1.2' },
-				{ parent: '1', id: '1.3', name: 'child1.3' }
-			]);
-
-			var grandparentObject = store.getSync('1.2');
-			children = store.getChildren(grandparentObject).fetchSync().slice();
-			assert.deepEqual(children, [
-				{ parent: '1.2', id: '1.2.1', name: 'grandchild1.2.1' },
-				{ parent: '1.2', id: '1.2.2', name: 'grandchild1.2.2' }
-			]);
-		}
+		'getChildren': createGetChildrenTest(store, 'parent'),
+		'getChildren (custom parentProperty)': createGetChildrenTest(customPropertyStore, 'parentId')
 	});
 });


### PR DESCRIPTION
While one could argue Tree is a simple reference implementation, it is perfectly usable as a mixin for hierarchical data when the parent-child relationship is tied by parent IDs.

Allowing the `parent` and `hasChildren` properties to be customized gives this even more mileage, rather than forcing services or client-side code to massage them to those specific names to work with this mixin.

Includes updates to Tree tests.
