### PR TITLE
Tree: Filter against root collection

### DIFF
--- a/Tree.js
+++ b/Tree.js
@@ -26,7 +26,7 @@ define([
 			//		Get the collection of objects with no parents
 			// returns: dstore/Store.Collection
 
-			return this.filter({ parent: null });
+			return this.root.filter({ parent: null });
 		},
 
 		getChildren: function (object) {
@@ -36,7 +36,7 @@ define([
 			//		The parent object
 			// returns: dstore/Store.Collection
 
-			return this.filter({ parent: this.getIdentity(object) });
+			return this.root.filter({ parent: this.getIdentity(object) });
 		}
 	});
 });


### PR DESCRIPTION
This fixes typos introduced in 510a43e421ff7cb42206586364ef18844ff9d15c.

There are apparently no unit tests for dstore/Tree at the moment; however, the regressions here can be observed with dgrid 0.4's unit tests.
