### PR TITLE
StoreAdapter: Add test and proposed fix for totalLength promise

### DIFF
--- a/legacy/StoreAdapter.js
+++ b/legacy/StoreAdapter.js
@@ -119,7 +119,7 @@ define([
 			if (results) {
 				// apply the object restoration
 				return new QueryResults(results.map(this._restore, this), {
-					totalLength: results.total
+					totalLength: when(results.total)
 				});
 			}
 			return results;

--- a/tests/legacy/StoreAdapter-Memory.js
+++ b/tests/legacy/StoreAdapter-Memory.js
@@ -55,6 +55,13 @@ define([
 			assert.strictEqual(results[1].describe(), 'four is not a prime');
 		},
 
+		fetch: function () {
+			var totalLength = store.fetch().totalLength;
+			assert.isDefined(totalLength, 'totalLength should be defined on fetch results');
+			assert.strictEqual(typeof totalLength.then, 'function',
+				'totalLength should be a promise');
+		},
+
 		'filter': function () {
 			assert.strictEqual(getResultsArray(store.filter({prime: true})).length, 3);
 			assert.strictEqual(getResultsArray(store.filter({even: true}))[1].name, 'four');


### PR DESCRIPTION
I noticed another `totalLength`-related API issue after removing what should be considered unnecessary `when` calls from dgrid.  It appears that `StoreAdapter` does not ensure that `totalLength` is a promise on adapted stores.

I've pushed a commit that adds a test for this, and proposes a fix.  I'm not sure whether this is really the right fix - I'm wondering whether it'd make sense to normalize this in `QueryResults` itself, instead.

I'd also ask that this be ported to the 1.0 branch for a 1.0.2, along with #97 when it's fixed.  dgrid 0.4.1 would benefit from these.  Thanks.