### PR TITLE
RequestMemory: Add refresh method

### DIFF
--- a/RequestMemory.js
+++ b/RequestMemory.js
@@ -3,11 +3,39 @@ define([
 	'./Request',
 	'./Cache'
 ], function(declare, Request, Cache) {
+
+	// module:
+	//		dstore/RequestMemory
+
 	return declare([ Request, Cache ], {
+		// summary:
+		//		A store which makes one request to a server for all of its data, then performs all
+		//		operations client-side.  Technically a composition of the Request and Cache stores.
+
+		isValidFetchCache: true,
+
 		postscript: function () {
 			this.inherited(arguments);
 			this.fetch();
 		},
-		isValidFetchCache: true
+
+		refresh: function (target) {
+			// summary:
+			//		Refreshes the store data from the current target or a new target.
+			// target: String?
+			//		Optional; new target to retrieve data from.  Uses the existing target by default.
+
+			if (this.fetchRequest) {
+				// Clear any currently-pending fetch request, since we're about to request again
+				this.fetchRequest.cancel();
+				this.fetchRequest = null;
+			}
+
+			if (target) {
+				this.target = target;
+			}
+			this.invalidate();
+			return this.fetch();
+		}
 	});
 });

--- a/docs/Stores.md
+++ b/docs/Stores.md
@@ -5,7 +5,7 @@ The dstore package includes several store implementations that can be used for t
 * `Memory` - This is a simple memory-based store that takes an array and provides access to the objects in the array through the store interface.
 * `Request` - This is a simple server-based collection that sends HTTP requests following REST conventions to access and modify data requested through the store interface.
 * `Rest` - This is a store built on `Request` that implements add, remove, and update operations using HTTP requests following REST conventions.
-* `RequestMemory` - This is a Memory based store that will retrieve its contents from a server/URL.
+* `RequestMemory` - This is a Memory-based store that will retrieve its contents from a server/URL.
 * `LocalDB` - This a store based on the browser's local database/storage capabilities. Data stored in this store will be persisted in the local browser.
 * `Cache` - This is a store mixin that combines a master and caching store to provide caching functionality.
 * `Trackable` - This a store mixin that adds index information to `add`, `update`, and `remove` events of tracked store instances. This adds a track() method for tracking stores.
@@ -72,8 +72,13 @@ This is the base class used for all stores, providing basic functionality for tr
 
 ## RequestMemory
 
-This store provides client-side querying functionality, but will load its data from the server, using the provided URL. This is
-an asynchronous store since queries and data retrieval may be made before the data has been retrieved from the server.
+This store provides client-side querying functionality, but will load its data from the server up-front, using the
+provided URL. This is an asynchronous store since queries and data retrieval may be made before the data has been
+retrieved from the server.
+
+`RequestMemory` accepts the same `target` option for its URL as `Request` and `Rest`. Additionally, it
+supports a `refresh` method which can be called (and optionally passed a new target URL) to reload data from
+the server endpoint.
 
 ## LocalDB
 


### PR DESCRIPTION
This adds a refresh method which will instruct the store to
reload its data from either the existing server endpoint, or a new
endpoint passed to the method.

Inspired by http://stackoverflow.com/a/28756348/237950 because people shouldn't need to be that intimately familiar with Cache to do this.

Includes tests, doc update, and some improved comments.

(Note: the diff here might make it look like this strips a newline-at-EOF... actually, there were _two_ trailing newlines, and it strips one of them.)
