### PR TITLE
Cache: Ensure add/put return a promise for read-only master stores

### DIFF
--- a/Cache.js
+++ b/Cache.js
@@ -127,9 +127,11 @@ define([
 			return when(this.inherited(arguments), function (result) {
 				// now put result in cache (note we don't do add, because add may have
 				// called put() and already added it)
-				cachingStore.put(object && typeof result === 'object' ? result : object, directives);
-				// the result from the add should be dictated by the master store and be unaffected by the cachingStore
-				return result;
+				var cachedPutResult =
+					cachingStore.put(object && typeof result === 'object' ? result : object, directives);
+				// the result from the add should be dictated by the master store and be unaffected by the cachingStore,
+				// unless the master store doesn't implement add
+				return result || cachedPutResult;
 			});
 		},
 		put: function (object, directives) {
@@ -138,9 +140,11 @@ define([
 			cachingStore.remove((directives && directives.id) || this.getIdentity(object));
 			return when(this.inherited(arguments), function (result) {
 				// now put result in cache
-				cachingStore.put(object && typeof result === 'object' ? result : object, directives);
-				// the result from the put should be dictated by the master store and be unaffected by the cachingStore
-				return result;
+				var cachedPutResult =
+					cachingStore.put(object && typeof result === 'object' ? result : object, directives);
+				// the result from the put should be dictated by the master store and be unaffected by the cachingStore,
+				// unless the master store doesn't implement put
+				return result || cachedPutResult;
 			});
 		},
 		remove: function (id, directives) {


### PR DESCRIPTION
Prior to this fix, Cache returns the result of `this.inherited(arguments)` for add and put, but that will be `undefined` if the master store doesn't implement those methods (which is the case with RequestMemory).

Note that for simplicity's sake, this fix presumes that the master store
adheres to the documented behavior of the add and put APIs, i.e. that it
returns an object; if it returns a falsy value, this fix will end up
returning the result of add/put on the caching store in that case too.

This commit also updates RequestMemory tests to remove when calls and test
Cache APIs for promises.  (Without the fixes in Cache.js, the add/put tests
will fail.)