### PR TITLE
Fix problem with DstoreAdapter being used with dstore/Request

### DIFF
--- a/legacy/DstoreAdapter.js
+++ b/legacy/DstoreAdapter.js
@@ -94,6 +94,8 @@ define([
 
 			var results = this.store.filter(query);
 			var queryResults;
+			var tracked;
+			var total;
 
 			// Apply sorting
 			var sort = options.sort;
@@ -108,7 +110,6 @@ define([
 				}
 			}
 
- 			var tracked;
 			if (results.track && !results.tracking) {
 				// if it is trackable, always track, so that observe can
 				// work properly.
@@ -123,9 +124,11 @@ define([
 					start: start,
 					end: options.count ? (start + options.count) : Infinity
 				});
-				queryResults.total = queryResults.totalLength;
 			}
-			queryResults = queryResults || new QueryResults(results[results.fetchSync ? 'fetchSync' : 'fetch']());
+			queryResults = queryResults || results[results.fetchSync ? 'fetchSync' : 'fetch']();
+			total = queryResults.totalLength;
+			queryResults = new QueryResults(queryResults);
+			queryResults.total = total;
 			queryResults.observe = function (callback, includeObjectUpdates) {
 				// translate observe to event listeners
 				function convertUndefined(value) {

--- a/tests/legacy/DstoreAdapter-Rest.js
+++ b/tests/legacy/DstoreAdapter-Rest.js
@@ -111,6 +111,16 @@ define([
 				i++;
 				assert.strictEqual(object.name, 'node' + i);
 			});
+		},
+		'query iterative with options': function () {
+			mockRequest.setResponseText(treeTestRootData);
+
+			var i = 0;
+			return store.query('data/treeTestRoot', { start: 0 }).map(function (object) {
+				i++;
+				assert.strictEqual(object.name, 'node' + i);
+				return object;
+			});
 		}
 	});
 });


### PR DESCRIPTION
When options were passed to DstoreAdapter#query, the results were not being wrapped by dojo/store/util/QueryResults.  When the store being adapted was dstore/Memory, there was not a problem because query returns and array which provides the same methods that QueryResults applies.  But the same was not true when the adapted store was dstore/Request.

My update makes sure the query results are always wrapped by DstoreAdapter#query.  I also added a simple test that catches the original defect.