### PR TITLE
The element might not be in the resultset Trackable (in case of comet-triggered emits)

### DIFF
--- a/Rest.js
+++ b/Rest.js
@@ -73,17 +73,17 @@ define([
 					? { 'X-Put-Default-Position': (this.defaultNewToStart ? 'start' : 'end') }
 					: null);
 
-			var r = request(hasId ? this.target + id : this.target, {
-					method: hasId && !options.incremental ? 'PUT' : 'POST',
-					data: this.stringify(object),
-					headers: lang.mixin({
-						'Content-Type': 'application/json',
-						Accept: this.accepts,
-						'If-Match': options.overwrite === true ? '*' : null,
-						'If-None-Match': options.overwrite === false ? '*' : null
-					}, positionHeaders, this.headers, options.headers)
-				});
-			return r.then(function (response) {
+			var initialResponse = request(hasId ? this.target + id : this.target, {
+				method: hasId && !options.incremental ? 'PUT' : 'POST',
+				data: this.stringify(object),
+				headers: lang.mixin({
+					'Content-Type': 'application/json',
+					Accept: this.accepts,
+					'If-Match': options.overwrite === true ? '*' : null,
+					'If-None-Match': options.overwrite === false ? '*' : null
+				}, positionHeaders, this.headers, options.headers)
+			})
+			return initialResponse.then(function (response) {
 				var event = {};
 
 				if ('beforeId' in options) {
@@ -92,9 +92,7 @@ define([
 
 				var result = event.target = store._restore(store.parse(response), true) || object;
 
-				when( r.response, function( httpResponse ){
-					console.log( httpResponse );
-					//store.emit(options.overwrite === false ? 'add' : 'update', event);
+				when( initialResponse.response, function( httpResponse ){
 					store.emit(httpResponse.status == 201 ? 'add' : 'update', event);
 				});
 

--- a/Trackable.js
+++ b/Trackable.js
@@ -261,6 +261,11 @@ define([
 							range = ranges[i];
 							for (j = range.start, l = j + range.count; j < l; ++j) {
 								var object = resultsArray[j];
+
+								// The object is not guaranteed to be there. If it's not, th
+								// there is no point in looking for it
+								if( ! object ) continue;
+
 								// often ids can be converted strings (if they are used as keys in objects),
 								// so we do a coercive equality check
 								/* jshint eqeqeq: false */


### PR DESCRIPTION
Hi there,

I am using Comet messages to update the cache of dstore stores in my application. Basically, the server fires up some messages instructing the application that a store named `storeName` was updated, and `object` is the new object. The application then runs a `notify()` for that object on that store, so that the UI is updated. This is the standard way this is done.
Now... there is a bit of a problem: in Trackable.js, we have:

```
                            var object = resultsArray[j];

                            // often ids can be converted strings (if they are used as keys in objects),
                            // so we do a coercive equality check
                            /* jshint eqeqeq: false */
                            if (store.getIdentity(object) == targetId) {
```

The problem is that here `object` is assumed to be defined, because in "normal" circumstances the object will be in the resultset.
However, there is an edge case where the `notify()` is fired, but the element is not in the resultset because of a filter. This will case getIdentity() to be run on `undefined`, and fail.

The patch simply prevents that from happening.

I realise this is a very edge case, and that this is not a very common case, but it does exist...

Thanks for listening!
