### PR TITLE
Fix _renderQueryParams

### DIFF
--- a/Request.js
+++ b/Request.js
@@ -245,17 +245,26 @@ define([
 
 		_renderQueryParams: function () {
 			var queryParams = [];
+			var filterEntries = [];
 
 			arrayUtil.forEach(this.queryLog, function (entry) {
 				var type = entry.type,
 					renderMethod = '_render' + type[0].toUpperCase() + type.substr(1) + 'Params';
 
-				if (this[renderMethod]) {
+				if (type === 'filter') {
+					filterEntries.push(entry.normalizedArguments[0]);
+				} else if (this[renderMethod]) {
 					push.apply(queryParams, this[renderMethod].apply(this, entry.normalizedArguments));
 				} else {
 					console.warn('Unable to render query params for "' + type + '" query', entry);
 				}
 			}, this);
+
+			if (filterEntries.length) {
+				var filter = new this.Filter();
+				var andFilter = filter.and.apply(filter, filterEntries);
+				queryParams.unshift.apply(queryParams, this._renderFilterParams(andFilter));
+			}
 
 			return queryParams;
 		},


### PR DESCRIPTION
If you have a Request store and you filter it with an OR operator and then later filter it with another filter the _renderQueryParams() method renders each filter from the queryLog separately. These rendered parameters are returned to _renderUrl() where they are joined together using the & symbol. No brackets are inserted around the OR term resulting in an incorrect request URL.

This fix combines 'filter' type queryLog entries in a manner which obeys order of precedence.
