### PR TITLE
Fix filter so logical operations are constructed correctly

### DIFF
--- a/tests/Request.js
+++ b/tests/Request.js
@@ -153,8 +153,7 @@ define([
 				var filter = new store.Filter();
 				var betweenTwoAndFour = filter.ne('id', 2).or(filter.eq('foo', true), filter.eq('foo'));
 				return runCollectionTest(store.filter(betweenTwoAndFour), { queryParams: {
-					id: 'ne=2',
-					'(foo': 'true|foo=undefined)'
+					id: 'ne=2|foo=true|foo=undefined'
 				}});
 			},
 


### PR DESCRIPTION
See the following gist for what this fixes. Also allows for nicer filter.or({key: value}) type filtering.

https://gist.github.com/jazdw/2410f64b99fbd9c104fa