### PR TITLE
Make default comparison assert that undefined > null > any other value.

### DIFF
--- a/SimpleQuery.js
+++ b/SimpleQuery.js
@@ -173,6 +173,7 @@ define([
 				data.sort(typeof sorted == 'function' ? sorted : function (a, b) {
 					for (var i = 0; i < sorted.length; i++) {
 						var comparison;
+						var isALessThanB;
 						var sorter = sorted[i];
 						if (typeof sorter == 'function') {
 							comparison = sorter(a, b);
@@ -184,10 +185,15 @@ define([
 
 							aValue != null && (aValue = aValue.valueOf());
 							bValue != null && (bValue = bValue.valueOf());
-
-							comparison = aValue === bValue
-								? 0
-								: (!!descending === (aValue === null || aValue > bValue && bValue !== null) ? -1 : 1);
+							if (aValue === bValue) {
+								comparison = 0;
+							}
+							else {
+								isALessThanB = typeof bValue === 'undefined' ||
+									bValue === null && typeof aValue !== 'undefined' ||
+									aValue != null && aValue < bValue;
+								comparison = !!descending === isALessThanB ? 1 : -1
+							}
 						}
 
 						if (comparison !== 0) {

--- a/tests/SimpleQuery.js
+++ b/tests/SimpleQuery.js
@@ -72,6 +72,65 @@ define([
 			]);
 		},
 
+		'sort null and undefined with strings': function () {
+			var sort = simpleQuery._createSortQuerier([ { property: 'name' } ]);
+			var sortDescending = simpleQuery._createSortQuerier([ { descending: true, property: 'name' } ]);
+			var data = testData.slice();
+			data.splice(2 , 0, { id: 6, odd: false });
+			data.splice(2, 0, { id: 7, name: null, odd: true });
+
+			assert.deepEqual(sort(data), [
+				{ id: 5, name: 'five', odd: true },
+				{ id: 4, name: 'four', odd: false },
+				{ id: 1, name: 'one', odd: true },
+				{ id: 3, name: 'three', odd: true },
+				{ id: 2, name: 'two', odd: false },
+				{ id: 7, name: null, odd: true },
+				{ id: 6, odd: false }
+			]);
+
+			assert.deepEqual(sortDescending(data), [
+				{ id: 6, odd: false },
+				{ id: 7, name: null, odd: true },
+				{ id: 2, name: 'two', odd: false },
+				{ id: 3, name: 'three', odd: true },
+				{ id: 1, name: 'one', odd: true },
+				{ id: 4, name: 'four', odd: false },
+				{ id: 5, name: 'five', odd: true }
+			]);
+		},
+
+		'sort null and undefined with numbers': function () {
+			var sort = simpleQuery._createSortQuerier([ { property: 'id' } ]);
+			var sortDescending = simpleQuery._createSortQuerier([ { descending: true, property: 'id' } ]);
+			var data = testData.slice();
+			data.splice(2 , 0, {});
+			data.splice(2, 0, { id: null});
+			data.splice(2, 0, { id: -1});
+
+			assert.deepEqual(sort(data), [
+				{ id: -1 },
+				{ id: 1, name: 'one', odd: true },
+				{ id: 2, name: 'two', odd: false },
+				{ id: 3, name: 'three', odd: true },
+				{ id: 4, name: 'four', odd: false },
+				{ id: 5, name: 'five', odd: true },
+				{ id: null},
+				{}
+			]);
+
+			assert.deepEqual(sortDescending(data), [
+				{},
+				{ id: null },
+				{ id: 5, name: 'five', odd: true },
+				{ id: 4, name: 'four', odd: false },
+				{ id: 3, name: 'three', odd: true },
+				{ id: 2, name: 'two', odd: false },
+				{ id: 1, name: 'one', odd: true },
+				{id: -1}
+			]);
+		},
+
 		'nested queries': function () {
 			var f = new Filter();
 			var isEven = f.eq('odd', false);


### PR DESCRIPTION
Fixes #131 by making the default comparison function created
in _createSortQuerier treat undefined as greater than any
value, and null greater than any value besides undefined.
This conveniently places all null and undefined values at
the end of a sorted list.