### PR TITLE
Ensure that StoreAdapter always returns a promise for 'fetch', etc.

### DIFF
--- a/legacy/StoreAdapter.js
+++ b/legacy/StoreAdapter.js
@@ -118,11 +118,11 @@ define([
 			var results = this.objectStore.query(queryObject, queryOptions);
 			if (results) {
 				// apply the object restoration
-				return new QueryResults(results.map(this._restore, this), {
+				return new QueryResults(when(results.map(this._restore, this)), {
 					totalLength: when(results.total)
 				});
 			}
-			return results;
+			return when(results);
 		}
 	});
 });

--- a/tests/legacy/StoreAdapter-AsyncMemory.js
+++ b/tests/legacy/StoreAdapter-AsyncMemory.js
@@ -5,9 +5,8 @@ define([
 	'intern/chai!assert',
 	'dojo/store/Memory',
 	'dojo/store/util/QueryResults',
-	'../sorting',
 	'dstore/legacy/StoreAdapter'
-], function (declare, Deferred, registerSuite, assert, Memory, QueryResults, sorting, StoreAdapter) {
+], function (declare, Deferred, registerSuite, assert, Memory, QueryResults, StoreAdapter) {
 
 	var Model = function () {};
 

--- a/tests/legacy/StoreAdapter-JsonRest.js
+++ b/tests/legacy/StoreAdapter-JsonRest.js
@@ -91,7 +91,7 @@ define([
 		},
 
 		'filter': function () {
-			return when(adaptedStore.filter('data/treeTestRoot').fetch()).then(function (results) {
+			return adaptedStore.filter('data/treeTestRoot').fetch().then(function (results) {
 				var object = results[0];
 				assert.strictEqual(object.name, 'node1');
 				assert.strictEqual(object.describe(), 'name is node1');

--- a/tests/legacy/StoreAdapter-Memory.js
+++ b/tests/legacy/StoreAdapter-Memory.js
@@ -3,9 +3,10 @@ define([
 	'intern!object',
 	'intern/chai!assert',
 	'dojo/store/Memory',
+	'dojo/promise/all',
 	'../sorting',
 	'dstore/legacy/StoreAdapter'
-], function (declare, registerSuite, assert, Memory, sorting, StoreAdapter) {
+], function (declare, registerSuite, assert, Memory, all, sorting, StoreAdapter) {
 
 	var Model = function () {};
 
@@ -98,8 +99,14 @@ define([
 		},
 
 		'filter with paging': function () {
-			assert.strictEqual(store.filter({prime: true}).fetchRange({start: 1, end: 2}).length, 1);
-			assert.strictEqual(store.filter({even: true}).fetchRange({start: 1, end: 2})[0].name, 'four');
+			return all([
+				store.filter({ even: true }).fetchRange({ start: 1, end: 2 }).then(function (results) {
+					assert.strictEqual(results[0].name, 'four');
+				}),
+				store.filter({ prime: true }).fetchRange({ start: 1, end: 2 }).then(function (results) {
+					assert.strictEqual(results.length, 1);
+				})
+			]);
 		},
 
 		'put update': function () {

--- a/tests/sorting.js
+++ b/tests/sorting.js
@@ -1,97 +1,100 @@
-define(['intern/chai!assert'], function (assert) {
-	return function createSortTests(name, before, sort) {
+define([
+	'intern/chai!assert',
+	'dojo/when'
+], function (assert, when) {
+	return function createSortTests (name, before, sort) {
 		return {
 			name: name,
 			beforeEach: before([
-				{id: 1, field1: 'one', field2: '1'},
-				{id: 2, field1: 'one', field2: '2'},
-				{id: 3, field1: 'two', field2: '5'},
-				{id: 4, field1: 'two', field2: '4'},
-				{id: 5, field1: 'two', field2: '3'},
-				{id: 6, field1: 'one', field2: '3'}
+				{ id: 1, field1: 'one', field2: '1' },
+				{ id: 2, field1: 'one', field2: '2' },
+				{ id: 3, field1: 'two', field2: '5' },
+				{ id: 4, field1: 'two', field2: '4' },
+				{ id: 5, field1: 'two', field2: '3' },
+				{ id: 6, field1: 'one', field2: '3' }
 			]),
 			'multiple sort fields - ascend + ascend': function () {
-
-				var results = sort({property: 'field1'},
-					{property: 'field2'});
-				/**
-				 * {id: 1, field1: 'one', field2: '1'},
-				 * {id: 2, field1: 'one', field2: '2'},
-				 * {id: 6, field1: 'one', field2: '3'}
-				 * {id: 5, field1: 'two', field2: '3'},
-				 * {id: 4, field1: 'two', field2: '4'},
-				 * {id: 3, field1: 'two', field2: '5'},
-				 */
-				assert.strictEqual(results.length, 6, 'Length is 6');
-				assert.strictEqual(results[0].id, 1);
-				assert.strictEqual(results[1].id, 2);
-				assert.strictEqual(results[2].id, 6);
-				assert.strictEqual(results[3].id, 5);
-				assert.strictEqual(results[4].id, 4);
-				assert.strictEqual(results[5].id, 3);
+				return when(sort({ property: 'field1' },
+					{ property: 'field2' })).then(function (results) {
+					/**
+					 * {id: 1, field1: 'one', field2: '1'},
+					 * {id: 2, field1: 'one', field2: '2'},
+					 * {id: 6, field1: 'one', field2: '3'}
+					 * {id: 5, field1: 'two', field2: '3'},
+					 * {id: 4, field1: 'two', field2: '4'},
+					 * {id: 3, field1: 'two', field2: '5'},
+					 */
+					assert.strictEqual(results.length, 6, 'Length is 6');
+					assert.strictEqual(results[ 0 ].id, 1);
+					assert.strictEqual(results[ 1 ].id, 2);
+					assert.strictEqual(results[ 2 ].id, 6);
+					assert.strictEqual(results[ 3 ].id, 5);
+					assert.strictEqual(results[ 4 ].id, 4);
+					assert.strictEqual(results[ 5 ].id, 3);
+				});
 			},
 
 			'multiple sort fields - ascend + descend': function () {
-
-				var results = sort({property: 'field1', descending: false},
-					{property: 'field2', descending: true});
-				assert.strictEqual(results.length, 6, 'Length is 6');
-				/**
-				 * {id: 6, field1: 'one', field2: '3'}
-				 * {id: 2, field1: 'one', field2: '2'},
-				 * {id: 1, field1: 'one', field2: '1'},
-				 * {id: 3, field1: 'two', field2: '5'},
-				 * {id: 4, field1: 'two', field2: '4'},
-				 * {id: 5, field1: 'two', field2: '3'},
-				 */
-				assert.strictEqual(results[0].id, 6);
-				assert.strictEqual(results[1].id, 2);
-				assert.strictEqual(results[2].id, 1);
-				assert.strictEqual(results[3].id, 3);
-				assert.strictEqual(results[4].id, 4);
-				assert.strictEqual(results[5].id, 5);
+				return when(sort({ property: 'field1', descending: false },
+					{ property: 'field2', descending: true })).then(function (results) {
+					assert.strictEqual(results.length, 6, 'Length is 6');
+					/**
+					 * {id: 6, field1: 'one', field2: '3'}
+					 * {id: 2, field1: 'one', field2: '2'},
+					 * {id: 1, field1: 'one', field2: '1'},
+					 * {id: 3, field1: 'two', field2: '5'},
+					 * {id: 4, field1: 'two', field2: '4'},
+					 * {id: 5, field1: 'two', field2: '3'},
+					 */
+					assert.strictEqual(results[ 0 ].id, 6);
+					assert.strictEqual(results[ 1 ].id, 2);
+					assert.strictEqual(results[ 2 ].id, 1);
+					assert.strictEqual(results[ 3 ].id, 3);
+					assert.strictEqual(results[ 4 ].id, 4);
+					assert.strictEqual(results[ 5 ].id, 5);
+				});
 			},
 
 			'multiple sort fields - descend + ascend': function () {
-
-				var results = sort({property: 'field1', descending: true},
-					{property: 'field2', descending: false});
-				/**
-				 * {id: 5, field1: 'two', field2: '3'},
-				 * {id: 4, field1: 'two', field2: '4'},
-				 * {id: 3, field1: 'two', field2: '5'},
-				 * {id: 1, field1: 'one', field2: '1'},
-				 * {id: 2, field1: 'one', field2: '2'},
-				 * {id: 6, field1: 'one', field2: '3'}
-				 */
-				assert.strictEqual(results.length, 6, 'Length is 6');
-				assert.strictEqual(results[0].id, 5);
-				assert.strictEqual(results[1].id, 4);
-				assert.strictEqual(results[2].id, 3);
-				assert.strictEqual(results[3].id, 1);
-				assert.strictEqual(results[4].id, 2);
-				assert.strictEqual(results[5].id, 6);
+				return when(sort({ property: 'field1', descending: true },
+					{ property: 'field2', descending: false })).then(function (results) {
+					/**
+					 * {id: 5, field1: 'two', field2: '3'},
+					 * {id: 4, field1: 'two', field2: '4'},
+					 * {id: 3, field1: 'two', field2: '5'},
+					 * {id: 1, field1: 'one', field2: '1'},
+					 * {id: 2, field1: 'one', field2: '2'},
+					 * {id: 6, field1: 'one', field2: '3'}
+					 */
+					assert.strictEqual(results.length, 6, 'Length is 6');
+					assert.strictEqual(results[ 0 ].id, 5);
+					assert.strictEqual(results[ 1 ].id, 4);
+					assert.strictEqual(results[ 2 ].id, 3);
+					assert.strictEqual(results[ 3 ].id, 1);
+					assert.strictEqual(results[ 4 ].id, 2);
+					assert.strictEqual(results[ 5 ].id, 6);
+				});
 			},
 
 			'multiple sort fields - descend + descend': function () {
-
-				var results = sort({property: 'field1',descending: true},
-					{property: 'field2', descending: true});
-				/**
-				 * {id: 3, field1: 'two', field2: '5'},
-				 * {id: 4, field1: 'two', field2: '4'},
-				 * {id: 5, field1: 'two', field2: '3'},
-				 * {id: 6, field1: 'one', field2: '3'}
-				 * {id: 2, field1: 'one', field2: '2'},
-				 * {id: 1, field1: 'one', field2: '1'},
-				 */
-				assert.strictEqual(results.length, 6, 'Length is 6');
-				assert.strictEqual(results[0].id, 3);
-				assert.strictEqual(results[1].id, 4);
-				assert.strictEqual(results[2].id, 5);
-				assert.strictEqual(results[3].id, 6);
-				assert.strictEqual(results[4].id, 2);
-				assert.strictEqual(results[5].id, 1);
+				return when(sort({ property: 'field1', descending: true },
+					{ property: 'field2', descending: true })).then(function (results) {
+					/**
+					 * {id: 3, field1: 'two', field2: '5'},
+					 * {id: 4, field1: 'two', field2: '4'},
+					 * {id: 5, field1: 'two', field2: '3'},
+					 * {id: 6, field1: 'one', field2: '3'}
+					 * {id: 2, field1: 'one', field2: '2'},
+					 * {id: 1, field1: 'one', field2: '1'},
+					 */
+					assert.strictEqual(results.length, 6, 'Length is 6');
+					assert.strictEqual(results[ 0 ].id, 3);
+					assert.strictEqual(results[ 1 ].id, 4);
+					assert.strictEqual(results[ 2 ].id, 5);
+					assert.strictEqual(results[ 3 ].id, 6);
+					assert.strictEqual(results[ 4 ].id, 2);
+					assert.strictEqual(results[ 5 ].id, 1);
+				});
 			}
 		};
 	};


### PR DESCRIPTION
Fixes #124 by wrapping the return value from StoreAdapter's
fetchRange function in a promise. This function is delegated
to by fetch so this handles both cases. Also updated several
test cases that were relying on the synchronous behavior of
the StoreAdapter.