### PR TITLE
Replace browser sniff with feature detection, fix unit tests in edge

### DIFF
--- a/tests/LocalDB.js
+++ b/tests/LocalDB.js
@@ -92,7 +92,7 @@ define([
 					try {
 						IDBKeyRange.only([ 1 ]);
 					} catch (error) {
-						// If we land here, we're in IE or Edge and multi entry is not supported
+						// If we land here, we're in IE or Edge and multiEntry is not supported
 						return;
 					}
 				}

--- a/tests/LocalDB.js
+++ b/tests/LocalDB.js
@@ -88,9 +88,13 @@ define([
 				options = undefined;
 			}
 			return function () {
-				if (options && options.multi && has('trident')) {
-					// sadly, IE doesn't support multiEntry yet
-					return;
+				if (options && options.multi) {
+					try {
+						IDBKeyRange.only([ 1 ]);
+					} catch (error) {
+						// If we land here, we're in IE or Edge and multi entry is not supported
+						return;
+					}
 				}
 				var i = 0;
 				var collection = numberStore.filter(filter, options);


### PR DESCRIPTION
This replaces the browser sniff for IE with a feature detection that catches Edge as well. Tested in IE/9/10/11, Edge, FireFox, and Chrome on windows and Safari, Firefox, and Chrome on mac. Passed in all, except for one test that failed on Safari. However, that test also fails for 1.1.

Fixes #169 