### PR TITLE
Fix 'or' and 'and' filters

### DIFF
--- a/SimpleQuery.js
+++ b/SimpleQuery.js
@@ -24,32 +24,32 @@ define([
 	}
 
 	var comparators = {
-		eq: function (value, required) {
+		eq: function eq(value, required) {
 			return value === required;
 		},
-		'in': function(value, required) {
+		'in': function inComparator(value, required) {
 			// allow for a collection of data
 			return arrayUtil.indexOf(required.data || required, value) > -1;
 		},
-		ne: function (value, required) {
+		ne: function ne(value, required) {
 			return value !== required;
 		},
-		lt: function (value, required) {
+		lt: function lt(value, required) {
 			return value < required;
 		},
-		lte: function (value, required) {
+		lte: function lte(value, required) {
 			return value <= required;
 		},
-		gt: function (value, required) {
+		gt: function gt(value, required) {
 			return value > required;
 		},
-		gte: function (value, required) {
+		gte: function gte(value, required) {
 			return value >= required;
 		},
-		match: function (value, required, object) {
+		match: function match(value, required, object) {
 			return required.test(value, object);
 		},
-		contains: function (value, required, object, key) {
+		contains: function contains(value, required, object, key) {
 			var collection = this;
 			var data;
 
@@ -86,8 +86,9 @@ define([
 			function getQuerier(filter) {
 				var type = filter.type;
 				var args = filter.args;
-				var comparator = collection._getFilterComparator(type);
-				if (comparator) {
+				var comparatorFunction = collection._getFilterComparator(type);
+
+				if (comparatorFunction) {
 					// it is a comparator
 					var firstArg = args[0];
 					var getProperty = makeGetter(firstArg, queryAccessors);
@@ -96,9 +97,10 @@ define([
 						// if it is a collection, fetch the contents (for `in` and `contains` operators)
 						secondArg = secondArg.fetchSync();
 					}
-					return function (object) {
+
+					return function comparator(object) {
 						// get the value for the property and compare to expected value
-						return comparator.call(collection, getProperty(object), secondArg, object, firstArg);
+						return comparatorFunction.call(collection, getProperty(object), secondArg, object, firstArg);
 					};
 				}
 				switch (type) {
@@ -110,10 +112,10 @@ define([
 								// combine the last querier with a new one
 								querier = (function(a, b) {
 									return type === 'and' ?
-										function(object) {
+										function and(object) {
 											return a(object) && b(object);
 										} :
-										function(object) {
+										function or(object) {
 											return a(object) || b(object);
 
 										};

--- a/SimpleQuery.js
+++ b/SimpleQuery.js
@@ -51,7 +51,17 @@ define([
 		},
 		contains: function (value, required, object, key) {
 			var collection = this;
-			return arrayUtil.every(required.data || required, function (requiredValue) {
+			var data;
+
+			if (required.data) {
+				data = required.data;
+			} else if(Array.isArray(required)) {
+				data = required;
+			} else {
+				data = [required];
+			}
+
+			return arrayUtil.every(data, function (requiredValue) {
 				if (typeof requiredValue === 'object' && requiredValue.type) {
 					var comparator = collection._getFilterComparator(requiredValue.type);
 					return arrayUtil.some(value, function (item) {

--- a/tests/Filter.js
+++ b/tests/Filter.js
@@ -1,0 +1,82 @@
+define([
+	'../Filter',
+	'../SimpleQuery',
+	'dojo/_base/declare',
+	'intern!tdd',
+	'intern/chai!assert'
+], function (Filter, SimpleQuery, declare, suite, assert) {
+	var testData = [
+		{ id: 1, name: 'one', odd: true },
+		{ id: 2, name: 'two', odd: false },
+		{ id: 3, name: 'three', odd: true },
+		{ id: 4, name: 'four', odd: false },
+		{ id: 5, name: 'five', odd: true }
+	];
+
+	suite.suite('Filter', function() {
+		var simpleQuery = new SimpleQuery();
+
+		suite.test('eq', function () {
+			var filterExpression = new Filter();
+			var filter = simpleQuery._createFilterQuerier(filterExpression.eq('odd', false));
+
+			assert.deepEqual(filter(testData), [
+				{ id: 2, name: 'two', odd: false },
+				{ id: 4, name: 'four', odd: false }
+			]);
+		});
+
+		suite.test('ne', function () {
+			var filterExpression = new Filter();
+			var filter = simpleQuery._createFilterQuerier(filterExpression.ne('odd', false));
+
+			assert.deepEqual(filter(testData), [
+				{ id: 1, name: 'one', odd: true },
+				{ id: 3, name: 'three', odd: true },
+				{ id: 5, name: 'five', odd: true }
+			]);
+		});
+
+		suite.test('lt', function () {
+			var filterExpression = new Filter();
+			var filter = simpleQuery._createFilterQuerier(filterExpression.lt('id', 3));
+
+			assert.deepEqual(filter(testData), [
+				{ id: 1, name: 'one', odd: true },
+				{ id: 2, name: 'two', odd: false }
+			]);
+		});
+
+		suite.test('lte', function () {
+			var filterExpression = new Filter();
+			var filter = simpleQuery._createFilterQuerier(filterExpression.lte('id', 3));
+
+			assert.deepEqual(filter(testData), [
+				{ id: 1, name: 'one', odd: true },
+				{ id: 2, name: 'two', odd: false },
+				{ id: 3, name: 'three', odd: true }
+			]);
+		});
+
+		suite.test('gt', function () {
+			var filterExpression = new Filter();
+			var filter = simpleQuery._createFilterQuerier(filterExpression.gt('id', 3));
+
+			assert.deepEqual(filter(testData), [
+				{ id: 4, name: 'four', odd: false },
+				{ id: 5, name: 'five', odd: true }
+			]);
+		});
+
+		suite.test('gte', function () {
+			var filterExpression = new Filter();
+			var filter = simpleQuery._createFilterQuerier(filterExpression.gte('id', 3));
+
+			assert.deepEqual(filter(testData), [
+				{ id: 3, name: 'three', odd: true },
+				{ id: 4, name: 'four', odd: false },
+				{ id: 5, name: 'five', odd: true }
+			]);
+		});
+	});
+});

--- a/tests/Filter.js
+++ b/tests/Filter.js
@@ -13,7 +13,7 @@ define([
 		{ id: 5, name: 'five', odd: true }
 	];
 
-	suite.suite('Filter', function() {
+	suite.suite('Filter', function () {
 		var simpleQuery = new SimpleQuery();
 
 		suite.test('eq', function () {
@@ -77,6 +77,283 @@ define([
 				{ id: 4, name: 'four', odd: false },
 				{ id: 5, name: 'five', odd: true }
 			]);
+		});
+
+		suite.test('contains', function () {
+			var filterExpression = new Filter();
+			var filter = simpleQuery._createFilterQuerier(filterExpression.contains('nums', 5));
+			var testData = [
+				{ id: 1, nums: [1, 2, 3] },
+				{ id: 2, nums: [4, 5, 6] },
+				{ id: 3, nums: [3, 4, 5] },
+				{ id: 4, nums: [7, 8, 9] },
+				{ id: 5, nums: [6, 7, 8] }
+			];
+
+			assert.deepEqual(filter(testData), [
+				{ id: 2, nums: [4, 5, 6] },
+				{ id: 3, nums: [3, 4, 5] }
+			]);
+		});
+
+		suite.test('in', function () {
+			var filterExpression = new Filter();
+			var filter = simpleQuery._createFilterQuerier(filterExpression.in('name', ['two', 'five']));
+
+			assert.deepEqual(filter(testData), [
+				{ id: 2, name: 'two', odd: false },
+				{ id: 5, name: 'five', odd: true }
+			]);
+		});
+
+		suite.test('match', function () {
+			var filterExpression = new Filter();
+			var filter = simpleQuery._createFilterQuerier(filterExpression.match('name', /f/));
+
+			assert.deepEqual(filter(testData), [
+				{ id: 4, name: 'four', odd: false },
+				{ id: 5, name: 'five', odd: true }
+			]);
+		});
+
+		suite.test('and', function () {
+			var filterExpression = new Filter();
+			var filter = simpleQuery._createFilterQuerier(filterExpression.and(
+				filterExpression.lt('id', 4),
+				filterExpression.eq('odd', true)
+			));
+
+			assert.deepEqual(filter(testData), [
+				{ id: 1, name: 'one', odd: true },
+				{ id: 3, name: 'three', odd: true }
+			]);
+		});
+
+		suite.test('or', function () {
+			var filterExpression = new Filter();
+			var filter = simpleQuery._createFilterQuerier(filterExpression.or(
+				filterExpression.eq('name', 'one'),
+				filterExpression.eq('id', 5)
+			));
+
+			assert.deepEqual(filter(testData), [
+				{ id: 1, name: 'one', odd: true },
+				{ id: 5, name: 'five', odd: true }
+			]);
+		});
+
+		suite.suite('chains', function () {
+			suite.test('eq', function () {
+				var filterExpression = new Filter();
+				var filter = simpleQuery._createFilterQuerier(filterExpression.eq('odd', false).eq('name', 'two'));
+
+				assert.deepEqual(filter(testData), [
+					{ id: 2, name: 'two', odd: false }
+				]);
+			});
+
+			suite.test('ne', function () {
+				var filterExpression = new Filter();
+				var filter = simpleQuery._createFilterQuerier(filterExpression.ne('odd', false).lt('id', 4));
+
+				assert.deepEqual(filter(testData), [
+					{ id: 1, name: 'one', odd: true },
+					{ id: 3, name: 'three', odd: true }
+				]);
+			});
+
+			suite.test('lt', function () {
+				var filterExpression = new Filter();
+				var filter = simpleQuery._createFilterQuerier(filterExpression.lt('id', 3).ne('name', 'one'));
+
+				assert.deepEqual(filter(testData), [
+					{ id: 2, name: 'two', odd: false }
+				]);
+			});
+
+			suite.test('lte', function () {
+				var filterExpression = new Filter();
+				var filter = simpleQuery._createFilterQuerier(filterExpression.lte('id', 3).eq('odd', true));
+
+				assert.deepEqual(filter(testData), [
+					{ id: 1, name: 'one', odd: true },
+					{ id: 3, name: 'three', odd: true }
+				]);
+			});
+
+			suite.test('gt', function () {
+				var filterExpression = new Filter();
+				var filter = simpleQuery._createFilterQuerier(filterExpression.gt('id', 3).eq('name', 'four'));
+
+				assert.deepEqual(filter(testData), [
+					{ id: 4, name: 'four', odd: false }
+				]);
+			});
+
+			suite.test('gte', function () {
+				var filterExpression = new Filter();
+				var filter = simpleQuery._createFilterQuerier(filterExpression.gte('id', 3).eq('odd', false));
+
+				assert.deepEqual(filter(testData), [
+					{ id: 4, name: 'four', odd: false }
+				]);
+			});
+
+			suite.test('contains', function () {
+				var filterExpression = new Filter();
+				var filter = simpleQuery._createFilterQuerier(filterExpression.contains('nums', 5).gt('id', 2));
+				var testData = [
+					{ id: 1, nums: [1, 2, 3] },
+					{ id: 2, nums: [4, 5, 6] },
+					{ id: 3, nums: [3, 4, 5] },
+					{ id: 4, nums: [7, 8, 9] },
+					{ id: 5, nums: [6, 7, 8] }
+				];
+
+				assert.deepEqual(filter(testData), [
+					{ id: 3, nums: [3, 4, 5] }
+				]);
+			});
+
+			suite.test('in', function () {
+				var filterExpression = new Filter();
+				var filter = simpleQuery._createFilterQuerier(filterExpression.in('name', ['two', 'five']).eq('odd', false));
+
+				assert.deepEqual(filter(testData), [
+					{ id: 2, name: 'two', odd: false }
+				]);
+			});
+
+			suite.test('match', function () {
+				var filterExpression = new Filter();
+				var filter = simpleQuery._createFilterQuerier(filterExpression.match('name', /f/).lt('id', 5));
+
+				assert.deepEqual(filter(testData), [
+					{ id: 4, name: 'four', odd: false }
+				]);
+			});
+
+			suite.test('and1', function () {
+				var filterExpression = new Filter();
+				var filter = simpleQuery._createFilterQuerier(filterExpression.and(
+					filterExpression.lt('id', 4).ne('name', 'three'),
+					filterExpression.eq('odd', true)
+				));
+
+				assert.deepEqual(filter(testData), [
+					{ id: 1, name: 'one', odd: true }
+				]);
+			});
+
+			suite.test('and2', function () {
+				var filterExpression = new Filter();
+				var filter = simpleQuery._createFilterQuerier(filterExpression.and(
+					filterExpression.eq('odd', true),
+					filterExpression.lt('id', 4).ne('name', 'three')
+				));
+
+				assert.deepEqual(filter(testData), [
+					{ id: 1, name: 'one', odd: true }
+				]);
+			});
+
+			suite.test('and3', function () {
+				var filterExpression = new Filter();
+				var filter = simpleQuery._createFilterQuerier(filterExpression.and(
+					filterExpression.gt('id', 1).lt('id', 8),
+					filterExpression.gt('id', 2).ne('odd', false)
+				));
+				var testData = [
+					{ id: 1, odd: true },
+					{ id: 2, odd: false },
+					{ id: 3, odd: true },
+					{ id: 4, odd: false },
+					{ id: 5, odd: true },
+					{ id: 6, odd: false },
+					{ id: 7, odd: true },
+					{ id: 8, odd: false }
+				]
+
+				assert.deepEqual(filter(testData), [
+					{ id: 3, odd: true },
+					{ id: 5, odd: true },
+					{ id: 7, odd: true }
+				]);
+			});
+
+			suite.test('and4', function () {
+				var filterExpression = new Filter();
+				var filter = simpleQuery._createFilterQuerier(filterExpression.and(
+					filterExpression.gt('id', 2).ne('odd', false),
+					filterExpression.gt('id', 1).lt('id', 8)
+				));
+				var testData = [
+					{ id: 1, odd: true },
+					{ id: 2, odd: false },
+					{ id: 3, odd: true },
+					{ id: 4, odd: false },
+					{ id: 5, odd: true },
+					{ id: 6, odd: false },
+					{ id: 7, odd: true },
+					{ id: 8, odd: false }
+				]
+
+				assert.deepEqual(filter(testData), [
+					{ id: 3, odd: true },
+					{ id: 5, odd: true },
+					{ id: 7, odd: true }
+				]);
+			});
+
+			suite.test('or1', function () {
+				var filterExpression = new Filter();
+				var filter = simpleQuery._createFilterQuerier(filterExpression.or(
+					filterExpression.eq('name', 'one').eq('odd', false),
+					filterExpression.eq('id', 5)
+				));
+
+				assert.deepEqual(filter(testData), [
+					{ id: 5, name: 'five', odd: true }
+				]);
+			});
+
+			suite.test('or2', function () {
+				var filterExpression = new Filter();
+				var filter = simpleQuery._createFilterQuerier(filterExpression.or(
+					filterExpression.eq('id', 5),
+					filterExpression.eq('name', 'one').eq('odd', false)
+				));
+
+				assert.deepEqual(filter(testData), [
+					{ id: 5, name: 'five', odd: true }
+				]);
+			});
+
+			suite.test('or3', function () {
+				var filterExpression = new Filter();
+				var filter = simpleQuery._createFilterQuerier(filterExpression.or(
+					filterExpression.gt('id', 1).eq('odd', true),
+					filterExpression.match('name', /f/).ne('name', 'four')
+				));
+
+				assert.deepEqual(filter(testData), [
+					{ id: 3, name: 'three', odd: true },
+					{ id: 5, name: 'five', odd: true }
+				]);
+			});
+
+			suite.test('or4', function () {
+				var filterExpression = new Filter();
+				var filter = simpleQuery._createFilterQuerier(filterExpression.or(
+					filterExpression.match('name', /f/).ne('name', 'four'),
+					filterExpression.gt('id', 1).eq('odd', true)
+				));
+
+				assert.deepEqual(filter(testData), [
+					{ id: 3, name: 'three', odd: true },
+					{ id: 5, name: 'five', odd: true }
+				]);
+			});
 		});
 	});
 });


### PR DESCRIPTION
Fix #179 and #189

* `SimpleQuery.js`: fix variable scoping of `querier` in `_createFilterQuerier` method
    * This was causing incorrect combination of unrelated querier functions
* `SimpleQuery.js`: fix `contains` comparator - should accept a non-array value as 2nd param
* add unit tests for filtering