### PR TITLE
fix #193: supply 'idProperty' value to DataStore constructor

### DIFF
--- a/tests/legacy/StoreAdapter-DojoData.js
+++ b/tests/legacy/StoreAdapter-DojoData.js
@@ -110,9 +110,9 @@ define([
 				perfect: true
 			}).then(function () {
 				dfd.reject('add duplicate should be rejected');
-			}, function () {
-				dfd.resolve();
-			});
+			}, dfd.callback(function (error) {
+				assert.strictEqual(error.message, 'Overwriting existing object not allowed');
+			}));
 		},
 
 		'add new': function () {

--- a/tests/legacy/StoreAdapter-DojoData.js
+++ b/tests/legacy/StoreAdapter-DojoData.js
@@ -103,13 +103,15 @@ define([
 
 
 		'add duplicate': function () {
+			var dfd = this.async();
+
 			store.add({
 				id: 5,
 				perfect: true
 			}).then(function () {
-				assert.fail('add duplicate not rejected');
+				dfd.reject('add duplicate should be rejected');
 			}, function () {
-				console.log('add duplicate failed as expected');
+				dfd.resolve();
 			});
 		},
 

--- a/tests/legacy/StoreAdapter-DojoData.js
+++ b/tests/legacy/StoreAdapter-DojoData.js
@@ -30,7 +30,8 @@ define([
 			var dataStore = new DataStore({
 				store: new ItemFileWriteStore({
 					data: lang.clone(testData)
-				})
+				}),
+				idProperty: 'id'
 			});
 			store = new StoreAdapter({
 				objectStore: dataStore,


### PR DESCRIPTION
Dojo's Data Store adapter, when used with `dojo/data/ItemFileWriteStore`, does not correctly set the default `idProperty` to `"id"`, so we have to explicitly supply it.