### PR TITLE
Fix trackable beforeId bug.

### DIFF
--- a/tests/Trackable.js
+++ b/tests/Trackable.js
@@ -582,6 +582,18 @@ define([
 				assert.strictEqual(data[data.length - 1].id, 3);
 			},
 
+			'updated item - with options.beforeId and no queryExecutor - update beforeId item': function () {
+				var store = createPrimeNumberStore(),
+					collection = store.track();
+				var data = collection._results;
+				store.put(store.getSync(4), { beforeId: 4 });
+
+				var len = data.length;
+				for (var i = 0; i < len; i++) {
+					assert.strictEqual(data[i].id, i, 'Item ' + i + ' is not correct.d');
+				}
+			},
+
 			'type': function () {
 				assert.isFalse(store === store.track(function () {}));
 			},


### PR DESCRIPTION
Note: the bug only affected a collection that did not have a query executor.  

In Trackable on a put, the notify code removes the item from its tracking arrays and then tries to update the arrays with the item's new location.  Before when the `beforeId` was the item's id, the item was removed from the tracking arrays.  When the code tried to add the item back to the tracking arrays, it was not added because the item referenced by `beforeId` was not found.  

This fix recognizes when the `beforeId` item is removed and when the item is to be reinserted into the tracking arrays, it now follows the same path as an update without using the `beforeId` option. 

Fix #207.