### PR TITLE
Mark cursor position in case cursor is reopened

### DIFF
--- a/db/IndexedDB.js
+++ b/db/IndexedDB.js
@@ -762,8 +762,7 @@ define([
 										// retry function, that we provide to the queue to use
 										// if the cursor can't be continued due to interruption
 										// if called, open the cursor again, and continue from our current position
-										advance = cachedPosition.preFilterOffset;
-										all.pop();
+										advance = (cachedPosition.preFilterOffset + 1);
 										openCursor();
 									});
 								});


### PR DESCRIPTION
This PR fixes an issue where multiple IndexedDB stores on a page will reset a cursor. It marks the previous cursor position so that it will resume its position in case the cursor is reset.

Resolves #195