### PR TITLE
Add filtering to event notifications

### DIFF
--- a/Store.js
+++ b/Store.js
@@ -127,8 +127,32 @@ define([
 				return data;
 			});
 		},
-		on: function (type, listener) {
-			return this.storage.on(type, listener);
+
+		matchesFilter: function (item) {
+			// Allow the event to continue if the queryLog is empty (no filtering).  Otherwise,
+			// only allow the event to propagate if the item matches the query log.
+			var queryLog = this.queryLog;
+			if (queryLog && item) {
+				var data = [item];
+				// iterate through the query log, applying each querier
+				for (var i = 0, l = queryLog.length; i < l; i++) {
+					data = queryLog[i].querier(data);
+				}
+				return data.length > 0;
+			} else {
+				return true;
+			}
+		},
+
+		on: function (type, listener, filterEvents) {
+			var self = this;
+			return this.storage.on(type, function (event) {
+				if (listener) {
+					if (!filterEvents || self.matchesFilter(event && event.target)) {
+						listener && listener(event);
+					}
+				}
+			});
 		},
 		emit: function (type, event) {
 			event = event || {};

--- a/docs/Collection.md
+++ b/docs/Collection.md
@@ -75,6 +75,10 @@ Property | Description
 
 This filters the collection, returning a new subset collection. The query can be an object, or a filter object, with the properties defining the constraints on matching objects. Some stores, like server or RQL stores, may accept string-based queries. Stores with in-memory capabilities (like `dstore/Memory`) may accept a function for filtering as well, but using the filter builder will ensure the greatest cross-store compatibility.
 
+#### `matchesFilter(item)`
+
+This tests the provided item to see if it matches the current filter or not.
+
 #### `sort(property, [descending])`
 
 This sorts the collection, returning a new ordered collection. Note that if sort is called multiple times, previous sort calls may be ignored by the store (it is up to store implementation how to handle that). If a multiple sort order is desired, use the array of sort orders defined by below.
@@ -106,7 +110,7 @@ Normally collections may defer the execution (like making an HTTP request) requi
 This fetches a range of objects from the collection, returning a promise to an array. The returned (and resolved) promise should have a `totalLength`
 property with a promise that resolves to a number indicating the total number of objects available in the collection.
 
-#### `on(type, listener)`
+#### `on(type, listener, filterEvents)`
 
 This allows you to define a listener for events that take place on the collection or parent store. When an event takes place, the listener will be called with an event object as the single argument. The following event types are defined:
 
@@ -115,6 +119,10 @@ Type | Description
 `add` | This indicates that a new object was added to the store. The new object is available on the `target` property.
 `update` | This indicates that an object in the stores was updated. The updated object is available on the `target` property.
 `delete` | This indicates that an object in the stores was removed. The id of the object is available on the `id` property.
+
+Setting `filterEvents` to `true` indicates the listener will be called only when the emitted event references an item (`event.target`) that satisfies the collection's current filter query. Note: if `filterEvents` is set to `true` for type `update`, the listener will be called only when the item passed to `put` matches the collection's query.  The original item will not be evaluted.  For example, a store contains items marked "to-do" and items marked "done" and one collection uses a query looking for "to-do" items and one looks for "done" items.  Both collections are listening for "update" events.  If an item is updated from "to-do" to "done", only the "done" collection will be notified of the update.
+
+If detecting when an item is removed from a collection due to an update is desired, set `filterEvents` to `false` and use the `matchesFilter(item)` method to test if each item updated is currently in the collection. 
 
 There is also a corresponding `emit(type, event)` method (from the [Store interface](Store.md#method-summary)) that can be used to emit events when objects have changed.
 

--- a/tests/all.js
+++ b/tests/all.js
@@ -11,6 +11,7 @@ define([
 	'./Tree',
 	'./Csv',
 	'./Tree',
+	'./multipleCollectionEvents',
 	'./extensions/RqlQuery',
 	'./legacy/DstoreAdapter-Memory',
 	'intern/node_modules/dojo/has!host-browser?./legacy/DstoreAdapter-Rest',

--- a/tests/multipleCollectionEvents.js
+++ b/tests/multipleCollectionEvents.js
@@ -1,0 +1,344 @@
+define([
+	'dstore/Memory',
+	'dstore/Trackable',
+	'intern!object',
+	'intern/chai!assert'
+], function (Memory, Trackable, registerSuite, assert){
+
+	var store;
+
+	function createEventHandlers(collection, filtered) {
+		var eventCounters = {
+			add: 0,
+			update: 0,
+			delete: 0
+		};
+		collection.on('add,update,delete', function (event) {
+			eventCounters[event.type]++;
+		}, filtered);
+		return eventCounters;
+	}
+
+	function assertEventCounters(eventCounters, expectedAdd, expectedUpdate, expectedDelete, failMessage) {
+		failMessage = failMessage || '';
+		assert.equal(eventCounters.add, expectedAdd, failMessage + ' - Unexpected add event count of ' + eventCounters.add + '. Expected ' + expectedAdd + '.');
+		assert.equal(eventCounters.update, expectedUpdate, failMessage + ' - Unexpected update event count of ' + eventCounters.update + '. Expected ' + expectedUpdate + '.');
+		assert.equal(eventCounters.delete, expectedDelete, failMessage + ' - Unexpected delete event count of ' + eventCounters.delete + '. Expected ' + expectedDelete + '.');
+	}
+
+	function createdFilteredEventSuite(name, Store) {
+		return {
+			name: name,
+
+			beforeEach: function(){
+
+				var testData = [
+					{ id: 1, name: 'one', odd: true },
+					{ id: 2, name: 'two', odd: false },
+					{ id: 3, name: 'three', odd: true },
+					{ id: 4, name: 'four', odd: false },
+					{ id: 5, name: 'five', odd: true }
+				];
+
+				store = new Store({data: testData});
+			},
+
+			'add to main store': function () {
+				var oddCollection = store.filter({odd: true});
+				var evenCollection = store.filter({odd: false});
+
+				var storeCounters = createEventHandlers(store);
+				var oddCounters = createEventHandlers(oddCollection, true);
+				var evenCounters = createEventHandlers(evenCollection, true);
+
+				store.add({ id: 10, name: 'one', odd: true });
+
+				assertEventCounters(storeCounters, 1, 0, 0, 'store');
+				assertEventCounters(oddCounters, 1, 0, 0, 'odd collection');
+				assertEventCounters(evenCounters, 0, 0, 0, 'even collection');
+			},
+
+			'add to filtered collection': function () {
+				var oddCollection = store.filter({odd: true});
+				var evenCollection = store.filter({odd: false});
+
+				var storeCounters = createEventHandlers(store);
+				var oddCounters = createEventHandlers(oddCollection, true);
+				var evenCounters = createEventHandlers(evenCollection, true);
+
+				oddCollection.add({ id: 10, name: 'one', odd: true });
+
+				assertEventCounters(storeCounters, 1, 0, 0, 'store');
+				assertEventCounters(oddCounters, 1, 0, 0, 'odd collection');
+				assertEventCounters(evenCounters, 0, 0, 0, 'even collection');
+			},
+
+			'remove from store': function () {
+				var oddCollection = store.filter({odd: true});
+				var evenCollection = store.filter({odd: false});
+
+				var storeCounters = createEventHandlers(store);
+				var oddCounters = createEventHandlers(oddCollection, true);
+				var evenCounters = createEventHandlers(evenCollection, true);
+
+				store.remove(3);
+
+				assertEventCounters(storeCounters, 0, 0, 1, 'store');
+				assertEventCounters(oddCounters, 0, 0, 1, 'odd collection');
+				assertEventCounters(evenCounters, 0, 0, 0, 'even collection');
+			},
+
+			'remove from filtered collection': function () {
+				var oddCollection = store.filter({odd: true});
+				var evenCollection = store.filter({odd: false});
+
+				var storeCounters = createEventHandlers(store);
+				var oddCounters = createEventHandlers(oddCollection, true);
+				var evenCounters = createEventHandlers(evenCollection, true);
+
+				oddCollection.remove(3);
+
+				assertEventCounters(storeCounters, 0, 0, 1, 'store');
+				assertEventCounters(oddCounters, 0, 0, 1, 'odd collection');
+				assertEventCounters(evenCounters, 0, 0, 0, 'even collection');
+			},
+
+			'update from store': function () {
+				var oddCollection = store.filter({odd: true});
+				var evenCollection = store.filter({odd: false});
+
+				var storeCounters = createEventHandlers(store);
+				var oddCounters = createEventHandlers(oddCollection, true);
+				var evenCounters = createEventHandlers(evenCollection, true);
+
+				store.put({ id: 3, name: 'three updated', odd: true });
+
+				assertEventCounters(storeCounters, 0, 1, 0, 'store');
+				assertEventCounters(oddCounters, 0, 1, 0, 'odd collection');
+				assertEventCounters(evenCounters, 0, 0, 0, 'even collection');
+
+				store.put({ id: 3, name: 'three updated', odd: false });
+
+				assertEventCounters(storeCounters, 0, 2, 0, 'store');
+				assertEventCounters(oddCounters, 0, 1, 0, 'odd collection');
+				assertEventCounters(evenCounters, 0, 1, 0, 'even collection');
+			},
+
+			'update from filtered collection': function () {
+				var oddCollection = store.filter({odd: true});
+				var evenCollection = store.filter({odd: false});
+
+				var storeCounters = createEventHandlers(store);
+				var oddCounters = createEventHandlers(oddCollection, true);
+				var evenCounters = createEventHandlers(evenCollection, true);
+
+				oddCollection.put({ id: 3, name: 'three updated', odd: true });
+
+				assertEventCounters(storeCounters, 0, 1, 0, 'store');
+				assertEventCounters(oddCounters, 0, 1, 0, 'odd collection');
+				assertEventCounters(evenCounters, 0, 0, 0, 'even collection');
+
+				oddCollection.put({ id: 3, name: 'three updated', odd: false });
+
+				assertEventCounters(storeCounters, 0, 2, 0, 'store');
+				assertEventCounters(oddCounters, 0, 1, 0, 'odd collection');
+				assertEventCounters(evenCounters, 0, 1, 0, 'even collection');
+			},
+
+			'multiple filters': function () {
+				var oddCollection = store.filter({odd: true}).filter({id: 3}).sort('name');
+				var evenCollection = store.filter({odd: false}).filter({id: 3}).sort('name');
+
+				var storeCounters = createEventHandlers(store);
+				var oddCounters = createEventHandlers(oddCollection, true);
+				var evenCounters = createEventHandlers(evenCollection, true);
+
+				store.put({ id: 1, name: 'one updated', odd: true });
+
+				assertEventCounters(storeCounters, 0, 1, 0, 'store');
+				assertEventCounters(oddCounters, 0, 0, 0, 'odd collection');
+				assertEventCounters(evenCounters, 0, 0, 0, 'even collection');
+
+				store.put({ id: 3, name: 'three updated', odd: true });
+
+				assertEventCounters(storeCounters, 0, 2, 0, 'store');
+				assertEventCounters(oddCounters, 0, 1, 0, 'odd collection');
+				assertEventCounters(evenCounters, 0, 0, 0, 'even collection');
+			},
+
+			'sort': function () {
+				var collectionOne = store.sort('id');
+
+				var storeCounters = createEventHandlers(store);
+				var oneCounters = createEventHandlers(collectionOne, true);
+
+				collectionOne.add({ id: 10, name: 'ten', odd: true });
+
+				assertEventCounters(storeCounters, 1, 0, 0, 'store');
+				assertEventCounters(oneCounters, 1, 0, 0, 'collection one');
+			}
+		};
+	}
+
+	function createdNotFilteredEventSuite(name, Store) {
+		return {
+			name: name,
+
+			beforeEach: function(){
+
+				var testData = [
+					{ id: 1, name: 'one', odd: true },
+					{ id: 2, name: 'two', odd: false },
+					{ id: 3, name: 'three', odd: true },
+					{ id: 4, name: 'four', odd: false },
+					{ id: 5, name: 'five', odd: true }
+				];
+
+				store = new Store({data: testData});
+			},
+
+			'add to main store': function () {
+				var oddCollection = store.filter({odd: true});
+				var evenCollection = store.filter({odd: false});
+
+				var storeCounters = createEventHandlers(store);
+				var oddCounters = createEventHandlers(oddCollection);
+				var evenCounters = createEventHandlers(evenCollection);
+
+				store.add({ id: 10, name: 'one', odd: true });
+
+				assertEventCounters(storeCounters, 1, 0, 0, 'store');
+				assertEventCounters(oddCounters, 1, 0, 0, 'odd collection');
+				assertEventCounters(evenCounters, 1, 0, 0, 'even collection');
+			},
+
+			'add to filtered collection': function () {
+				var oddCollection = store.filter({odd: true});
+				var evenCollection = store.filter({odd: false});
+
+				var storeCounters = createEventHandlers(store);
+				var oddCounters = createEventHandlers(oddCollection);
+				var evenCounters = createEventHandlers(evenCollection);
+
+				oddCollection.add({ id: 10, name: 'one', odd: true });
+
+				assertEventCounters(storeCounters, 1, 0, 0, 'store');
+				assertEventCounters(oddCounters, 1, 0, 0, 'odd collection');
+				assertEventCounters(evenCounters, 1, 0, 0, 'even collection');
+			},
+
+			'remove from store': function () {
+				var oddCollection = store.filter({odd: true});
+				var evenCollection = store.filter({odd: false});
+
+				var storeCounters = createEventHandlers(store);
+				var oddCounters = createEventHandlers(oddCollection);
+				var evenCounters = createEventHandlers(evenCollection);
+
+				store.remove(3);
+
+				assertEventCounters(storeCounters, 0, 0, 1, 'store');
+				assertEventCounters(oddCounters, 0, 0, 1, 'odd collection');
+				assertEventCounters(evenCounters, 0, 0, 1, 'even collection');
+			},
+
+			'remove from filtered collection': function () {
+				var oddCollection = store.filter({odd: true});
+				var evenCollection = store.filter({odd: false});
+
+				var storeCounters = createEventHandlers(store);
+				var oddCounters = createEventHandlers(oddCollection);
+				var evenCounters = createEventHandlers(evenCollection);
+
+				oddCollection.remove(3);
+
+				assertEventCounters(storeCounters, 0, 0, 1, 'store');
+				assertEventCounters(oddCounters, 0, 0, 1, 'odd collection');
+				assertEventCounters(evenCounters, 0, 0, 1, 'even collection');
+			},
+
+			'update from store': function () {
+				var oddCollection = store.filter({odd: true});
+				var evenCollection = store.filter({odd: false});
+
+				var storeCounters = createEventHandlers(store);
+				var oddCounters = createEventHandlers(oddCollection);
+				var evenCounters = createEventHandlers(evenCollection);
+
+				store.put({ id: 3, name: 'three updated', odd: true });
+
+				assertEventCounters(storeCounters, 0, 1, 0, 'store');
+				assertEventCounters(oddCounters, 0, 1, 0, 'odd collection');
+				assertEventCounters(evenCounters, 0, 1, 0, 'even collection');
+
+				store.put({ id: 3, name: 'three updated', odd: false });
+
+				assertEventCounters(storeCounters, 0, 2, 0, 'store');
+				assertEventCounters(oddCounters, 0, 2, 0, 'odd collection');
+				assertEventCounters(evenCounters, 0, 2, 0, 'even collection');
+			},
+
+			'update from filtered collection': function () {
+				var oddCollection = store.filter({odd: true});
+				var evenCollection = store.filter({odd: false});
+
+				var storeCounters = createEventHandlers(store);
+				var oddCounters = createEventHandlers(oddCollection);
+				var evenCounters = createEventHandlers(evenCollection);
+
+				oddCollection.put({ id: 3, name: 'three updated', odd: true });
+
+				assertEventCounters(storeCounters, 0, 1, 0, 'store');
+				assertEventCounters(oddCounters, 0, 1, 0, 'odd collection');
+				assertEventCounters(evenCounters, 0, 1, 0, 'even collection');
+
+				oddCollection.put({ id: 3, name: 'three updated', odd: false });
+
+				assertEventCounters(storeCounters, 0, 2, 0, 'store');
+				assertEventCounters(oddCounters, 0, 2, 0, 'odd collection');
+				assertEventCounters(evenCounters, 0, 2, 0, 'even collection');
+			},
+
+			'multiple filters': function () {
+				var oddCollection = store.filter({odd: true}).filter({id: 3}).sort('name');
+				var evenCollection = store.filter({odd: false}).filter({id: 3}).sort('name');
+
+				var storeCounters = createEventHandlers(store);
+				var oddCounters = createEventHandlers(oddCollection);
+				var evenCounters = createEventHandlers(evenCollection);
+
+				store.put({ id: 1, name: 'one updated', odd: true });
+
+				assertEventCounters(storeCounters, 0, 1, 0, 'store');
+				assertEventCounters(oddCounters, 0, 1, 0, 'odd collection');
+				assertEventCounters(evenCounters, 0, 1, 0, 'even collection');
+
+				store.put({ id: 3, name: 'three updated', odd: true });
+
+				assertEventCounters(storeCounters, 0, 2, 0, 'store');
+				assertEventCounters(oddCounters, 0, 2, 0, 'odd collection');
+				assertEventCounters(evenCounters, 0, 2, 0, 'even collection');
+			},
+
+			'sort': function () {
+				var collectionOne = store.sort('id');
+
+				var storeCounters = createEventHandlers(store);
+				var oneCounters = createEventHandlers(collectionOne);
+
+				collectionOne.add({ id: 10, name: 'ten', odd: true });
+
+				assertEventCounters(storeCounters, 1, 0, 0, 'store');
+				assertEventCounters(oneCounters, 1, 0, 0, 'collection one');
+			}
+		};
+	}
+
+	registerSuite(createdFilteredEventSuite('dstore multiple collection notifications', Memory));
+
+	registerSuite(createdFilteredEventSuite('dstore multiple tracked collection notifications', Memory.createSubclass(Trackable)));
+
+	registerSuite(createdNotFilteredEventSuite('dstore multiple collection notifications not filtered', Memory));
+
+	registerSuite(createdNotFilteredEventSuite('dstore multiple tracked collection notifications not filtered', Memory.createSubclass(Trackable)));
+});


### PR DESCRIPTION
Fixes #188

This update modifies `Store#on` to support limiting calls to event listeners for items that match the current collection's query log.

There isn't a perfect solution for this `update` scenario:

- A store contains items marked "to-do" and items marked "done".
- One collection is created using `filter(query)` that looks for "to-do" items.
- A second collection is created using `filter(query)` that looks for "done" items.  
- Both collections are listening for "update" events with the `filterEvents` parameters set to `true`. 
- An item is updated via `put(item)` that changes the item from "to-do" to "done".

In the above scenario, only the second, "done" collection will be notified.  The dstore code does not have a reliable reference to the old version of the item.  dstore does not maintain immutable items.  You can write code that fetches an item from a store like `Memory` and change the item  that was returned by the store.  That will actually modify the item in the Memory store.  There's no requirement to call `put` unless  `update` events need to be emitted.  But that behavior makes it impossible to retrieve the original item.  

Therefore, the event handling code can't grab the original item when an update event occurs to see if the current collection previously contained the item being updated.

So to accommodate the scenario above, the event listeners can be registered with `filterEvents` set to `false` or `undefined` and the provided event listener can call `matchesFilter(item)` to see if the item is in the current collection or not and update the UI accordingly.

