### PR TITLE
Cache store: fix logic that tests for valid result in add and put

### DIFF
--- a/Cache.js
+++ b/Cache.js
@@ -140,7 +140,7 @@ define([
 				// now put result in cache (note we don't do add, because add may have
 				// called put() and already added it)
 				var cachedPutResult =
-					cachingStore.put(object && typeof result === 'object' ? result : object, directives);
+					cachingStore.put(result && typeof result === 'object' ? result : object, directives);
 				// the result from the add should be dictated by the master store and be unaffected by the cachingStore,
 				// unless the master store doesn't implement add
 				return result || cachedPutResult;
@@ -154,7 +154,7 @@ define([
 			return when(this.inherited(arguments)).then(function (result) {
 				// now put result in cache
 				var cachedPutResult =
-					cachingStore.put(object && typeof result === 'object' ? result : object, directives);
+					cachingStore.put(result && typeof result === 'object' ? result : object, directives);
 				// the result from the put should be dictated by the master store and be unaffected by the cachingStore,
 				// unless the master store doesn't implement put
 				return result || cachedPutResult;


### PR DESCRIPTION
bug fix: when adding/putting data, if the target store returns a non-null result object, use it to update caching store, otherwise use the original data object.
wrong expr: "object && typeof result === 'object' ? result : object"
right expr: "result && typeof result === 'object' ? result : object"