### PR TITLE
Store#emit: if storage.emit throws an error, log it instead of hiding it

### DIFF
--- a/Store.js
+++ b/Store.js
@@ -158,7 +158,11 @@ define([
 			event.type = type;
 			try {
 				return this.storage.emit(type, event);
-			} finally {
+			}
+			catch (error) {
+				console.error(error);
+			}
+			finally {
 				// Return the initial value of event.cancelable because a listener error makes it impossible
 				// to know whether the event was actually canceled
 				return event.cancelable;


### PR DESCRIPTION
`Store#emit`: if `storage.emit` throws an error, log it instead of hiding it

Fixes #187