### PR TITLE
Improve TypeScript typedefs

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/SitePen/dstore"
   },
   "dependencies": {
+    "@types/dojo": "^1.9.0",
     "dojo": "^1.9.0"
   },
   "devDependencies": {
@@ -19,5 +20,6 @@
     "lib": "."
   },
   "main": "./Store",
+  "types": "./typings/dstore.d.ts",
   "dojoBuild": "package.js"
 }

--- a/typings/dstore.d.ts
+++ b/typings/dstore.d.ts
@@ -1,4 +1,4 @@
-/// <reference path="../dojo/dojo.d.ts" />
+/// <reference types="dojo" />
 
 declare module dstore {
 	export interface FetchArray<T> extends Array<T> {
@@ -298,6 +298,7 @@ declare module 'dstore/RequestMemory' {
 		filter(query: string | {} | { (item: T, index: number): boolean; }): RequestMemory<T>;
 		invalidate(): void;
 		isAvailableInCache(): void;
+		refresh(target?: string): dstore.FetchPromise<T>;
 		sort(property: string | { (a: T, b: T): number; }, descending?: boolean): RequestMemory<T>;
 		track(): RequestMemory<T>;
 	}


### PR DESCRIPTION
* Set `"types"` field in `package.json`
* Add `@types/dojo` to `dependencies`
* Use package reference `"types"` property in typedefs
* Add `RequestMemory#refresh` method to typedefs

Fixes #209